### PR TITLE
Added missing cologne in help-string

### DIFF
--- a/plugins/memo.rb
+++ b/plugins/memo.rb
@@ -72,7 +72,7 @@ class Cinch::Memo
   recognize /memo for (.*?): (.*)/i, :method => :memoize
 
   set :help, <<-HELP
-cinch memo for <nick>: <message>
+cinch: memo for <nick>: <message>
   Makes me remember a notice for <nick>. When <nick> joins the
   channel, I’ll post <message> indicating you told me to do so.
   If <nick> doesn’t join for a long time, I’ll discard the memo.


### PR DESCRIPTION
Still needs proper substitution of the bots name, probably use &lt;botname&gt; until substitution works?
